### PR TITLE
Make Where a collection

### DIFF
--- a/src/AbstractClause.php
+++ b/src/AbstractClause.php
@@ -12,9 +12,8 @@ abstract class AbstractClause extends Collection implements Stringable {
     protected string $clause;
     protected string $separator = ",";
 
-    protected array $items = [];
-
     public function __construct(protected Builder $query) {
+        parent::__construct();
     }
 
     public function getClause(): string {
@@ -25,17 +24,12 @@ abstract class AbstractClause extends Collection implements Stringable {
         return $this->separator;
     }
 
-    public function getItems(): array {
-        return $this->items;
-    }
-
     public function __toString(): string {
-        $items = $this->getItems();
-        if (empty($items)) {
+        if (empty($this->getItems())) {
             return "";
         }
 
-        $value = $this->query::arrayToString($items, "{$this->getSeparator()} ");
+        $value = $this->query::arrayToString($this, "{$this->getSeparator()} ");
 
         return "{$this->getClause()} $value";
     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -13,6 +13,7 @@ use JPI\Database\Query\Result\CollectionInterface;
 use JPI\Database\Query\Result\PaginatedCollection;
 use JPI\Database\Query\Result\PaginatedCollectionInterface;
 use JPI\Database\Query\Result\Row;
+use Traversable;
 
 /**
  * Query builder. Allows building SQL queries also executing them and receiving in appropriate format.
@@ -120,7 +121,8 @@ class Builder implements WhereableInterface, ParamableInterface {
      * Convenient function to pluck/get out the single value from an array if it's the only value.
      * Then build a string value if an array.
      */
-    public static function arrayToString(array $value, string $separator = ","): string {
+    public static function arrayToString(Traversable|array $value, string $separator = ","): string {
+        $value = iterator_to_array($value);
         if (count($value) === 1) {
             return (string)array_shift($value);
         }

--- a/src/Clause/Join.php
+++ b/src/Clause/Join.php
@@ -44,8 +44,4 @@ class Join extends AbstractClause {
     public function getClause(): string {
         return "$this->clause $this->table ON";
     }
-
-    public function getItems(): array {
-        return $this->wheres;
-    }
 }

--- a/src/Clause/Where.php
+++ b/src/Clause/Where.php
@@ -9,10 +9,10 @@ use JPI\Database\Query\Clause\Where\AndCondition;
 class Where extends AndCondition {
 
     public function __toString(): string {
-        if (empty($this->wheres)) {
+        if (empty($this->getItems())) {
             return "";
         }
 
-        return "WHERE " . $this->query::arrayToString($this->wheres, " {$this->getCondition()} ");
+        return "WHERE " . $this->query::arrayToString($this, " {$this->getCondition()} ");
     }
 }

--- a/src/Clause/Where/Condition.php
+++ b/src/Clause/Where/Condition.php
@@ -9,9 +9,10 @@ use JPI\Database\Query\DelegatedParamableTrait;
 use JPI\Database\Query\ParamableInterface;
 use JPI\Database\Query\WhereableInterface;
 use JPI\Database\Query\WhereableTrait;
+use JPI\Utils\Collection;
 use Stringable;
 
-abstract class Condition implements WhereableInterface, ParamableInterface, Stringable {
+abstract class Condition extends Collection implements WhereableInterface, ParamableInterface, Stringable {
 
     use DelegatedParamableTrait;
     use WhereableTrait;
@@ -19,6 +20,7 @@ abstract class Condition implements WhereableInterface, ParamableInterface, Stri
     protected string $condition;
 
     public function __construct(protected Builder $query) {
+        parent::__construct();
     }
 
     public function getCondition(): string {
@@ -26,12 +28,12 @@ abstract class Condition implements WhereableInterface, ParamableInterface, Stri
     }
 
     public function __toString(): string {
-        $count = count($this->wheres);
+        $count = count($this);
         if (!$count) {
             return "";
         }
 
-        $clause = $this->query::arrayToString($this->wheres, " {$this->getCondition()} ");
+        $clause = $this->query::arrayToString($this, " {$this->getCondition()} ");
 
         if ($count > 1) {
             return "($clause)";

--- a/src/WhereableTrait.php
+++ b/src/WhereableTrait.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace JPI\Database\Query;
 
+/**
+ * Assumes this is used in a class implementing ArrayAccess where the items are the where clauses.
+ */
 trait WhereableTrait {
-
-    protected array $wheres = [];
 
     abstract public function param(string $key, string|int|float $value): static;
 
@@ -16,7 +17,7 @@ trait WhereableTrait {
         string|int|float|array|null $valueOrPlaceholder = null
     ): static {
         if ($expression === null && $valueOrPlaceholder === null) {
-            $this->wheres[] = $whereOrColumn;
+            $this[] = $whereOrColumn;
             return $this;
         }
 
@@ -38,7 +39,7 @@ trait WhereableTrait {
             $placeholder = $valueOrPlaceholder;
         }
 
-        $this->wheres[] = "$whereOrColumn $expression $placeholder";
+        $this[] = "$whereOrColumn $expression $placeholder";
         return $this;
     }
 }


### PR DESCRIPTION
This makes more sense.

This also means the `Join` clause uses the `items` property for it's `on` clauses and not a separate `wheres`.

Means both are countable, can access entries like a normal array.