### PR TITLE
Support for Between in expression

### DIFF
--- a/src/WhereableTrait.php
+++ b/src/WhereableTrait.php
@@ -23,6 +23,13 @@ trait WhereableTrait {
             return $this;
         }
 
+        if ($operator === "BETWEEN") {
+            $this->param("{$columnOrExpression}_1", $valueOrPlaceholder[0]);
+            $this->param("{$columnOrExpression}_2", $valueOrPlaceholder[1]);
+            $this[] = "$columnOrExpression BETWEEN :{$columnOrExpression}_1 AND :{$columnOrExpression}_2";
+            return $this;
+        }
+
         if (is_array($valueOrPlaceholder) && count($valueOrPlaceholder) === 1) {
             $operator = $operator === "NOT IN" ? "<>" : "=";
             $valueOrPlaceholder = reset($valueOrPlaceholder);

--- a/tests/WhereClauseTest.php
+++ b/tests/WhereClauseTest.php
@@ -40,37 +40,6 @@ final class WhereClauseTest extends TestCase {
         $this->assertSame("column = :column", (string)$where);
         $this->assertSame(["column" => 1], $this->getParams($builder));
 
-        // IN
-        $builder = $this->createPartialMock(Builder::class, []);
-        $where = $builder->newAndCondition()->where("column", "IN", [2, 3]);
-        $this->assertSame("column IN (:column_1, :column_2)", (string)$where);
-        $this->assertSame(
-            [
-                "column_1" => 2,
-                "column_2" => 3,
-            ],
-            $this->getParams($builder)
-        );
-
-        // Single value array should use = instead of IN
-        $builder = $this->createPartialMock(Builder::class, []);
-        $where = $builder->newAndCondition()->where("column", "IN", [1]);
-        $this->assertSame("column = :column", (string)$where);
-        $this->assertSame(["column" => 1], $this->getParams($builder));
-
-        // NOT IN
-        $builder = $this->createPartialMock(Builder::class, []);
-        $where = $builder->newAndCondition()->where("column", "NOT IN", [7, 8, 9]);
-        $this->assertSame("column NOT IN (:column_1, :column_2, :column_3)", (string)$where);
-        $this->assertSame(
-            [
-                "column_1" => 7,
-                "column_2" => 8,
-                "column_3" => 9,
-            ],
-            $this->getParams($builder)
-        );
-
         // Multiple
         $builder = $this->createPartialMock(Builder::class, []);
         $where = $builder->newAndCondition()
@@ -105,37 +74,6 @@ final class WhereClauseTest extends TestCase {
         $where = $builder->newOrCondition()->where("column", "=", 1);
         $this->assertSame("column = :column", (string)$where);
         $this->assertSame(["column" => 1], $this->getParams($builder));
-
-        // IN
-        $builder = $this->createPartialMock(Builder::class, []);
-        $where = $builder->newOrCondition()->where("column", "IN", [2, 3]);
-        $this->assertSame("column IN (:column_1, :column_2)", (string)$where);
-        $this->assertSame(
-            [
-                "column_1" => 2,
-                "column_2" => 3,
-            ],
-            $this->getParams($builder)
-        );
-
-        // Single value array should use = instead of IN
-        $builder = $this->createPartialMock(Builder::class, []);
-        $where = $builder->newOrCondition()->where("column", "IN", [1]);
-        $this->assertSame("column = :column", (string)$where);
-        $this->assertSame(["column" => 1], $this->getParams($builder));
-
-        // NOT IN
-        $builder = $this->createPartialMock(Builder::class, []);
-        $where = $builder->newOrCondition()->where("column", "NOT IN", [7, 8, 9]);
-        $this->assertSame("column NOT IN (:column_1, :column_2, :column_3)", (string)$where);
-        $this->assertSame(
-            [
-                "column_1" => 7,
-                "column_2" => 8,
-                "column_3" => 9,
-            ],
-            $this->getParams($builder)
-        );
 
         // Multiple
         $builder = $this->createPartialMock(Builder::class, []);
@@ -175,40 +113,6 @@ final class WhereClauseTest extends TestCase {
         $this->assertSame("WHERE column = :column", (string)$where);
         $this->assertSame(["column" => 1], $this->getParams($builder));
 
-        // IN
-        $builder = $this->createPartialMock(Builder::class, []);
-        $where = new Where($builder);
-        $where->where("column", "IN", [1, 2]);
-        $this->assertSame("WHERE column IN (:column_1, :column_2)", (string)$where);
-        $this->assertSame(
-            [
-                "column_1" => 1,
-                "column_2" => 2,
-            ],
-            $this->getParams($builder)
-        );
-
-        // Single value array should use = instead of IN
-        $builder = $this->createPartialMock(Builder::class, []);
-        $where = new Where($builder);
-        $where->where("column", "IN", [1]);
-        $this->assertSame("WHERE column = :column", (string)$where);
-        $this->assertSame(["column" => 1], $this->getParams($builder));
-
-        // NOT IN
-        $builder = $this->createPartialMock(Builder::class, []);
-        $where = new Where($builder);
-        $where->where("column", "NOT IN", [7, 8, 9]);
-        $this->assertSame("WHERE column NOT IN (:column_1, :column_2, :column_3)", (string)$where);
-        $this->assertSame(
-            [
-                "column_1" => 7,
-                "column_2" => 8,
-                "column_3" => 9,
-            ],
-            $this->getParams($builder)
-        );
-
         // Multiple
         $builder = $this->createPartialMock(Builder::class, []);
         $where = new Where($builder);
@@ -239,6 +143,40 @@ final class WhereClauseTest extends TestCase {
 
     #[AllowMockObjectsWithoutExpectations]
     public function testOperators(): void {
+        // Single value array should use = instead of IN
+        $builder = $this->createPartialMock(Builder::class, []);
+        $where = new Where($builder);
+        $where->where("column", "IN", [1]);
+        $this->assertSame("WHERE column = :column", (string)$where);
+        $this->assertSame(["column" => 1], $this->getParams($builder));
+
+        // IN
+        $builder = $this->createPartialMock(Builder::class, []);
+        $where = new Where($builder);
+        $where->where("column", "IN", [1, 2]);
+        $this->assertSame("WHERE column IN (:column_1, :column_2)", (string)$where);
+        $this->assertSame(
+            [
+                "column_1" => 1,
+                "column_2" => 2,
+            ],
+            $this->getParams($builder)
+        );
+
+        // NOT IN
+        $builder = $this->createPartialMock(Builder::class, []);
+        $where = new Where($builder);
+        $where->where("column", "NOT IN", [7, 8, 9]);
+        $this->assertSame("WHERE column NOT IN (:column_1, :column_2, :column_3)", (string)$where);
+        $this->assertSame(
+            [
+                "column_1" => 7,
+                "column_2" => 8,
+                "column_3" => 9,
+            ],
+            $this->getParams($builder)
+        );
+
         // BETWEEN
         $builder = $this->createPartialMock(Builder::class, []);
         $where = new Where($builder);

--- a/tests/WhereClauseTest.php
+++ b/tests/WhereClauseTest.php
@@ -236,4 +236,30 @@ final class WhereClauseTest extends TestCase {
         $this->assertSame("WHERE column = :column AND (column = 8 OR column = 9)", (string)$where);
         $this->assertSame(["column" => 7], $this->getParams($builder));
     }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testOperators(): void {
+        // BETWEEN
+        $builder = $this->createPartialMock(Builder::class, []);
+        $where = new Where($builder);
+        $where->where("column_one", "BETWEEN", [100, 200]);
+        $this->assertSame("WHERE column_one BETWEEN :column_one_1 AND :column_one_2", (string)$where);
+        $this->assertSame([
+            "column_one_1" => 100,
+            "column_one_2" => 200,
+        ], $this->getParams($builder));
+
+        // Multiple BETWEEN
+        $builder = $this->createPartialMock(Builder::class, []);
+        $where = new Where($builder);
+        $where->where("column_one", "BETWEEN", [1, 2]);
+        $where->where("column_two", "BETWEEN", [3, 4]);
+        $this->assertSame("WHERE column_one BETWEEN :column_one_1 AND :column_one_2 AND column_two BETWEEN :column_two_1 AND :column_two_2", (string)$where);
+        $this->assertSame([
+            "column_one_1" => 1,
+            "column_one_2" => 2,
+            "column_two_1" => 3,
+            "column_two_2" => 4,
+        ], $this->getParams($builder));
+    }
 }


### PR DESCRIPTION
Closes https://github.com/jahidulpabelislam/query/issues/39.

`operator` needs to be `BETWEEN` and have `valueOrPlaceholder` of an array containing 2 values.

If value isn't an array with 2 values PHP will error.
