### PR TITLE
Support count for particular column

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -241,12 +241,12 @@ class Builder implements WhereableInterface, ParamableInterface {
         return new static::$paginatedCollectionClass($this->createResults($rows), $totalCount, $limit, $page);
     }
 
-    public function count(): int {
+    public function count(string $column = "*"): int {
         // Clear/reset
         $this->columns = [];
         $this->orderBy->clear();
 
-        $this->column("COUNT(*)", "count");
+        $this->column("COUNT($column)", "count");
         $this->limit(1, 1);
 
         $row = $this->database->selectFirst($this->getSelectQuery(), $this->params);


### PR DESCRIPTION
Closes https://github.com/jahidulpabelislam/query/issues/44.

By default it will still do `COUNT(*)`, but can pass a column name to `count` method.